### PR TITLE
Allows edges to have multiple labels

### DIFF
--- a/bce/core.py
+++ b/bce/core.py
@@ -122,7 +122,7 @@ def explore(initcube, fullperm=False):
                     int2cube[counter] = new
                 newedge = (cube2int[tuple(cube)], cube2int[tuple(new)])
                 edges.append(newedge)
-                edgelabels[newedge] = facename
+                edgelabels[newedge] = edgelabels.get(newedge,"")+facename
 
     return verts, edges, edgelabels, int2cube, cube2int
 


### PR DESCRIPTION
If there are multiple face turns between the same nodes, the edge label needs to contain all the possible turns.
For example if the shape A can become shape B by doing the face moves D, F, B, the edge label will be "DFB" instead of one of them.